### PR TITLE
[bt#12985] WH/OUT cannot be validated

### DIFF
--- a/sale_order_lot_selection/models/stock.py
+++ b/sale_order_lot_selection/models/stock.py
@@ -26,13 +26,6 @@ class StockMove(models.Model):
             strict=strict,
         )
 
-    def _prepare_move_line_vals(self, quantity=None, reserved_quant=None):
-        vals = super()._prepare_move_line_vals(
-            quantity=quantity, reserved_quant=reserved_quant
-        )
-        if reserved_quant and self.sale_line_id:
-            vals["lot_id"] = self.sale_line_id.lot_id.id
-        return vals
     def _get_sol_lot_id(self):
         if self.sale_line_id:
             return self.sale_line_id.lot_id


### PR DESCRIPTION
The method deleted is a duplicated caused via bad conflict resolution of this same method commented a few lines below.

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.braintec-group.com/web#view_type=form&model=helpdesk.ticket&id=12985">[bt#12985] WH/OUT cannot be validated</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>sale_order_lot_selection</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->