### PR TITLE
[bt#12546][bt#12985] sale_order_lot_selection: Doesn't Work for Multi-Step Delivery Route

### DIFF
--- a/sale_order_lot_selection/models/sale_order.py
+++ b/sale_order_lot_selection/models/sale_order.py
@@ -43,15 +43,22 @@ class SaleOrder(models.Model):
     def _check_related_moves(self):
         if self.env.context.get("skip_check_lot_selection_qty", False):
             return True
-        for line in self.order_line:
-            if line.lot_id:
-                moves = line.move_ids._get_assigned_move_ids()
-                unreserved_moves = moves.filtered(
-                    lambda move: move.product_uom_qty != move.reserved_availability
-                )
-                if unreserved_moves:
-                    raise UserError(
-                        _("Can't reserve products for lot %s") % line.lot_id.name
+
+        # When the reservation mode in the Stock Settings is set to Immediately, we need to check for unreserved moves.
+        # ('1', 'Immediately after sales order confirmation'),  -- module installed
+        # ('0', 'Manually or based on automatic scheduler')     -- module uninstalled
+        procurement_jit_module = self.env['ir.module.module'].search([('name', '=', 'procurement_jit')])
+        if procurement_jit_module and procurement_jit_module.state == 'installed':
+            for line in self.order_line:
+                if line.lot_id:
+                    moves = line.move_ids._get_assigned_move_ids()
+                    unreserved_moves = moves.filtered(
+                        lambda move: move.product_uom_qty != move.reserved_availability
                     )
-            self._check_move_state(line)
+                    if unreserved_moves:
+                        raise UserError(
+                            _("Can't reserve products for lot %s") % line.lot_id.name
+                        )
+                self._check_move_state(line)
+
         return True

--- a/sale_order_lot_selection/models/stock.py
+++ b/sale_order_lot_selection/models/stock.py
@@ -44,11 +44,14 @@ class StockMove(models.Model):
            move_ids |= move._get_assigned_move_ids()
         return move_ids
 
-    # This method seems not to be necessary (bt#11722)
-    # def _prepare_move_line_vals(self, quantity=None, reserved_quant=None):
-    #     vals = super()._prepare_move_line_vals(
-    #         quantity=quantity, reserved_quant=reserved_quant
-    #     )
-    #     if reserved_quant and self.sale_line_id and self.sale_line_id.lot_id:
-    #         vals["lot_id"] = self.sale_line_id.lot_id.id
-    #     return vals
+    # This method has caused some issues with tickets: bt#11722, bt#12546, bt#12985
+    # In some cases it does not work because the lot can not be found in the sales order line, but it could be found
+    # in the moves. So we are enhancing this method to do both actions using the method "_get_sol_lot_id"
+    def _prepare_move_line_vals(self, quantity=None, reserved_quant=None):
+        vals = super()._prepare_move_line_vals(
+            quantity=quantity, reserved_quant=reserved_quant
+        )
+        lot_id = self._get_sol_lot_id()
+        if reserved_quant and lot_id:
+            vals["lot_id"] = lot_id.id
+        return vals


### PR DESCRIPTION


<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.braintec-group.com/web#view_type=form&model=helpdesk.ticket&id=12546">[bt#12546] [mt#982] sale_order_lot_selection: Doesn't Work for Multi-Step Delivery Route</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>sale_order_lot_selection</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->