### PR TITLE
[t134661] Change Sale Order Line Commitment Date Field From Datetime to Date

### DIFF
--- a/sale_order_line_date/models/sale_order_line.py
+++ b/sale_order_line_date/models/sale_order_line.py
@@ -14,7 +14,7 @@ from odoo import fields, models
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
-    commitment_date = fields.Datetime("Delivery Date")
+    commitment_date = fields.Date("Delivery Date")
 
     def _prepare_procurement_values(self, group_id=False):
         vals = super(SaleOrderLine, self)._prepare_procurement_values(group_id)

--- a/sale_order_line_date/tests/test_sale_order_line_date.py
+++ b/sale_order_line_date/tests/test_sale_order_line_date.py
@@ -107,7 +107,9 @@ class TestSaleOrderLineDates(TransactionCase):
         picking = self.sale2.picking_ids
         self.assertEqual(len(picking), 1)
         # It should be the latest -> dt2
-        self._assert_equal_dates(picking.scheduled_date, self.dt2 - datetime.timedelta(days=1))
+        self._assert_equal_dates(
+            picking.scheduled_date, self.dt2 - datetime.timedelta(days=1)
+        )
         self._assert_equal_dates(picking.date_deadline, self.dt2)
         # security_lead 1 day.
         self._assert_equal_dates(

--- a/sale_order_line_date/tests/test_sale_order_line_date.py
+++ b/sale_order_line_date/tests/test_sale_order_line_date.py
@@ -97,7 +97,7 @@ class TestSaleOrderLineDates(TransactionCase):
         picking = self.sale1.picking_ids
         self.assertEqual(len(picking), 1)
         # it should be the earliest (3 line commitment_date is not set) -> dt1
-        self.assertEqual(picking.scheduled_date, self.dt1 - datetime.timedelta(days=1))
+        self._assert_equal_dates(picking.scheduled_date, self.dt1 - datetime.timedelta(days=1))
         self.assertEqual(picking.date_deadline, self.dt1)
         self.assertEqual(self.sale2.picking_policy, "direct")
         self.sale2.picking_policy = "one"

--- a/sale_order_line_date/tests/test_sale_order_line_date.py
+++ b/sale_order_line_date/tests/test_sale_order_line_date.py
@@ -97,16 +97,18 @@ class TestSaleOrderLineDates(TransactionCase):
         picking = self.sale1.picking_ids
         self.assertEqual(len(picking), 1)
         # it should be the earliest (3 line commitment_date is not set) -> dt1
-        self._assert_equal_dates(picking.scheduled_date, self.dt1 - datetime.timedelta(days=1))
-        self.assertEqual(picking.date_deadline, self.dt1)
+        self._assert_equal_dates(
+            picking.scheduled_date, self.dt1 - datetime.timedelta(days=1)
+        )
+        self._assert_equal_dates(picking.date_deadline, self.dt1)
         self.assertEqual(self.sale2.picking_policy, "direct")
         self.sale2.picking_policy = "one"
         self.sale2.action_confirm()
         picking = self.sale2.picking_ids
         self.assertEqual(len(picking), 1)
         # It should be the latest -> dt2
-        self.assertEqual(picking.scheduled_date, self.dt2 - datetime.timedelta(days=1))
-        self.assertEqual(picking.date_deadline, self.dt2)
+        self._assert_equal_dates(picking.scheduled_date, self.dt2 - datetime.timedelta(days=1))
+        self._assert_equal_dates(picking.date_deadline, self.dt2)
         # security_lead 1 day.
         self._assert_equal_dates(
             self.sale_line4.commitment_date - datetime.timedelta(days=1),

--- a/sale_order_line_date/tests/test_sale_order_line_date.py
+++ b/sale_order_line_date/tests/test_sale_order_line_date.py
@@ -86,9 +86,9 @@ class TestSaleOrderLineDates(TransactionCase):
         self.assertEqual(self.sale1.commitment_date, self.dt2)
         self.sale1.write({"commitment_date": self.dt3})
         self.sale1._onchange_commitment_date()
-        self.assertEqual(self.sale_line1.commitment_date, self.dt1)
-        self.assertEqual(self.sale_line2.commitment_date, self.dt2)
-        self.assertEqual(self.sale_line3.commitment_date, self.dt3)
+        self._assert_equal_dates(self.sale_line1.commitment_date, self.dt1)
+        self._assert_equal_dates(self.sale_line2.commitment_date, self.dt2)
+        self._assert_equal_dates(self.sale_line3.commitment_date, self.dt3)
 
     def test_02_shipping_policies(self):
         """Test if dates are propagated correctly taking into


### PR DESCRIPTION
Changes the field '**sale_order_line.commitment_date**' Field From `Datetime` to `Date`.

This is to avoid discrepancies in the expected date when it is formatted on a report document as a plain date without time information, for example [here](https://github.com/brain-tec/sale-workflow/blob/c2cfdfad594043b649322cc98800427055915fa0/sale_order_line_date/reports/sale_order_report.xml#L15). Discrepancies can occur when a salesman sets the commitment date around midnight in his time zone, or near a daylight saving time shift. As the time zone, and thus the UTC offset, might be different when the datetime is converted to a date and printed in a report, the shown formatted date can be different than what was originally entered.
The customer PTEC does only use commitment dates without time information, and thus that part can be discarded altogether.


<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://braintec.com/web#view_type=form&model=project.task&id=134661">[t134661] Lieferdatum auf Dokumenten falsch, wenn 0 Uhr verwendet wird</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>sale_order_line_date</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->