### PR TITLE
[t136753] Changing onchange method that no longer exists in v16

### DIFF
--- a/sale_order_secondary_unit/models/sale_order.py
+++ b/sale_order_secondary_unit/models/sale_order.py
@@ -30,7 +30,7 @@ class SaleOrderLine(models.Model):
         self._onchange_helper_product_uom_for_secondary()
 
     @api.onchange("product_id")
-    def product_id_change(self):
+    def _onchange_product_id_warning(self):
         """
         If default sales secondary unit set on product, put on secondary
         quantity 1 for being the default quantity. We override this method,
@@ -39,7 +39,7 @@ class SaleOrderLine(models.Model):
         """
         # Determine if we compute the sale line with one unit of secondary uom as default.
         # Based on method of sale order line _update_taxes
-        res = super().product_id_change()
+        res = super()._onchange_product_id_warning()
         line_uom_qty = self.product_uom_qty
         self.secondary_uom_id = self.product_id.sale_secondary_uom_id
         if self.product_id.sale_secondary_uom_id:


### PR DESCRIPTION
UPDATE **sale_order_secondary_unit**

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://braintec.com/web#view_type=form&model=project.task&id=136753">[t136753] Module: Secondary Unit of measurement</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>sale_order_secondary_unit</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->